### PR TITLE
ppu.c: fix wrong color in left attribute

### DIFF
--- a/ppu.c
+++ b/ppu.c
@@ -154,7 +154,7 @@ void ppu_draw_background_scanline(bool mirror)
                 
                 word attribute_address = (ppu_base_nametable_address() + (mirror ? 0x400 : 0) + 0x3C0 + (tile_x >> 2) + (ppu.scanline >> 5) * 8);
                 bool top = (ppu.scanline % 32) < 16;
-                bool left = (tile_x % 32 < 16);
+                bool left = (tile_x % 4 < 2);
 
                 byte palette_attribute = ppu_ram_read(attribute_address);
 


### PR DESCRIPTION
This fixes wrong color in Super Mario Bros. The credits goes to @ydb-beep.

See: https://github.com/NJU-ProjectN/LiteNES/issues/2